### PR TITLE
Make the project compilable with OpenCL 3.x+ headers

### DIFF
--- a/main.c
+++ b/main.c
@@ -510,7 +510,7 @@ void framebuffer_draw(t_framebuffer *self)
     clock_t t1 = clock() / (CLOCKS_PER_SEC / 1000);
     
     if(camera.keyD == sfTrue)
-        printf("GPU enabled: %s | Time : %lu ms\n", camera.keyG ? "CL_TRUE " : "CL_FALSE", t1 - t0);
+        printf("GPU enabled: %s | Time : %lu ms\n", camera.keyG ? "true " : "false", t1 - t0);
 }
 
 

--- a/main.c
+++ b/main.c
@@ -7,10 +7,14 @@
 //
 
 #include <assert.h>
+
 #include <stdio.h>
+#include <stdbool.h>
 
 #include <SFML/Graphics.h>
-#include <OpenCL/OpenCL.h>
+
+#define CL_TARGET_OPENCL_VERSION 300
+#include <CL/cl.h>
 
 typedef cl_double t_double;
 typedef cl_uint t_uint;

--- a/main.c
+++ b/main.c
@@ -9,7 +9,6 @@
 #include <assert.h>
 
 #include <stdio.h>
-#include <stdbool.h>
 
 #include <SFML/Graphics.h>
 
@@ -307,7 +306,7 @@ cl_int clGetPlatformAndDeviceIDs(cl_platform_id *pid, cl_device_id *did)
     cl_uint ds;
     cl_platform_id pids[1024];
     cl_device_id dids[1024];
-    cl_bool first = true;
+    cl_bool first = CL_TRUE;
     cl_uint max = 0;
     cl_int err;
     
@@ -334,18 +333,18 @@ cl_int clGetPlatformAndDeviceIDs(cl_platform_id *pid, cl_device_id *did)
             if (err != CL_SUCCESS)
                 return (err);
             
-            if (first == true || n > max)
+            if (first == CL_TRUE || n > max)
             {
                 *pid = pids[i];
                 *did = dids[j];
-                first = false;
+                first = CL_FALSE;
                 max = n;
             }
         }
     }
     assert(max > 0);
     
-    if (true) {
+    if (CL_TRUE) {
         char name[1024];
         
         err = clGetPlatformInfo(*pid, CL_PLATFORM_NAME, sizeof(name) / sizeof(*name), &name, NULL);
@@ -511,7 +510,7 @@ void framebuffer_draw(t_framebuffer *self)
     clock_t t1 = clock() / (CLOCKS_PER_SEC / 1000);
     
     if(camera.keyD == sfTrue)
-        printf("GPU enabled: %s | Time : %lu ms\n", camera.keyG ? "true " : "false", t1 - t0);
+        printf("GPU enabled: %s | Time : %lu ms\n", camera.keyG ? "CL_TRUE " : "CL_FALSE", t1 - t0);
 }
 
 


### PR DESCRIPTION
This pull request allow for the project to be compiled against OpenCL 3.x and above.

This essentially fixes the OpenCL header `include` directive as well as using the corresponding `CL_TRUE` and `CL_FALSE` values instead of the C standard `true` and `false` ones.